### PR TITLE
set the package.json 'private' field to true,

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "focus-app",
   "version": "1.0.0",
   "description": "focus-app: An Ionic project",
+  "private": true,
   "dependencies": {
     "gulp": "^3.5.6",
     "gulp-sass": "^1.3.3",


### PR DESCRIPTION
so that npm doesn't yield and warnings about missing license and repository fields
