### PR TITLE
Add server skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ www/css/ionic.app.min.css
 www/lib
 sounds/
 .idea/
+backend/download/
+

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,23 @@
+var express = require('express');
+var app = express();
+var path = require('path');
+var fs = require('fs');
+var auth = require('basic-authentication')({
+  user: process.env.FOCUS_USER || 'test',
+  password: process.env.FOCUS_PASSWORD || 'test'
+});
+
+var route = process.env.FOCUS_ROUTE || '/download';
+var port = process.env.FOCUS_PORT || '3000';
+var DOWNLOAD_FOLDER = './backend/download/'
+var basic_path = path.resolve(DOWNLOAD_FOLDER + 'basic.zip');
+
+/* This will download a zip-file as an attachment. */
+/* HTTP Basic authentication on the route */
+app.get(route, auth, function(req, res) {
+  res.download(basic_path);
+});
+
+var server = app.listen(port, function () {
+  console.log('App listening at port %s', port);
+});

--- a/package.json
+++ b/package.json
@@ -4,16 +4,21 @@
   "description": "focus-app: An Ionic project",
   "private": true,
   "dependencies": {
+    "basic-authentication": "~1.6.0",
+    "express": "~4.13.3",
     "gulp": "^3.5.6",
-    "gulp-sass": "^1.3.3",
     "gulp-concat": "^2.2.0",
     "gulp-minify-css": "^0.3.0",
-    "gulp-rename": "^1.2.0"
+    "gulp-rename": "^1.2.0",
+    "gulp-sass": "^1.3.3"
   },
   "devDependencies": {
     "bower": "^1.3.3",
     "gulp-util": "^2.2.14",
     "shelljs": "^0.3.0"
+  },
+  "scripts": {
+    "start": "node backend/server.js"
   },
   "cordovaPlugins": [
     "cordova-plugin-device",


### PR DESCRIPTION
The route /download is secured with HTTP basic, meaning that one needs an Authorization header with a username and password Base64-encoded. Also, the server presumes that there exists a `basic.zip`
file in `backend/download`.

`npm start` will start the server. `node backend/server.js` works as well. 
